### PR TITLE
メンバー一覧ページを作成

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,4 +4,6 @@ mkdocs-build:
 
 .PHONY: mkdocs-serve
 mkdocs-serve:
-	docker run --rm -it -p 8000:8000 -v ${PWD}:/docs squidfunk/mkdocs-material
+	docker run --rm -it -p 8000:8000 -v ${PWD}:/docs squidfunk/mkdocs-material serve \
+	  --livereload \
+	  --dev-addr 0.0.0.0:8000

--- a/docs/members.md
+++ b/docs/members.md
@@ -34,9 +34,9 @@
 
     ---
 
-    ![Image title](https://dummyimage.com/128x128/eee/aaa){ align=left }
+    ![Image title](https://avatars.githubusercontent.com/u/29663697?v=4){ align=left }
 
-    自己紹介
+    大学でオペレーションズ・リサーチ，数理最適化の研究をやっています．
 
     ---
 

--- a/docs/members.md
+++ b/docs/members.md
@@ -1,0 +1,75 @@
+<div class="grid cards" markdown>
+
+-   :material-account-outline: __Atsuhiro Hada__
+
+    ---
+
+    ![Image title](https://dummyimage.com/128x128/eee/aaa){ align=left }
+
+    自己紹介
+
+    ---
+
+
+-   :material-account-outline: __Jiro Iwanaga__
+
+    ---
+
+    ![Image title](https://dummyimage.com/128x128/eee/aaa){ align=left }
+
+    自己紹介
+
+    ---
+
+
+-   :material-account-outline: __Ken Kobayashi__
+
+    ---
+
+    ![Image title](https://dummyimage.com/128x128/eee/aaa){ align=left }
+
+    自己紹介
+
+    ---
+
+
+-   :material-account-outline: __Mitsuhisa Ota__
+
+    ---
+
+    ![Image title](https://dummyimage.com/128x128/eee/aaa){ align=left }
+
+    自己紹介
+
+    ---
+
+
+-   :material-account-outline: __Shuhei Fujiwara__
+
+    ---
+
+    ![Image title](https://lh3.googleusercontent.com/d/1CDKct38rF_4i0ehI00yItPCfleHachzO){ width=128 align=left }
+    データサイエンティストや MLOps エンジニアを経て、現在は最適化システムを作る仕事をしています。
+    大学では連続最適化の研究をしていました。
+
+    Google Developer Expert (AI・Google Cloud)。
+
+    ---
+    [:fontawesome-brands-github: __sfujiwara__](https://github.com/sfujiwara)
+
+    [:fontawesome-brands-x-twitter: __@shuhei_fujiwara__](https://x.com/shuhei_fujiwara)
+
+    [:fontawesome-solid-link: __sfujiwara.net__](https://sfujiwara.net)
+
+
+-   :material-account-outline: __Shunji Umetani__
+
+    ---
+
+    ![Image title](https://dummyimage.com/128x128/eee/aaa){ align=left }
+
+    自己紹介
+
+    ---
+
+</div>

--- a/docs/members.md
+++ b/docs/members.md
@@ -4,11 +4,19 @@
 
     ---
 
-    ![Image title](https://dummyimage.com/128x128/eee/aaa){ align=left }
+    ![Image title](https://avatars.githubusercontent.com/u/43230737?v=4){ width=128 align=left }
 
-    自己紹介
+    データ受託分析の会社でデータサイエンティストとして働いています。大学では微分方程式と機械学習周りの研究をしていましたが会社では最適化のモデリングをやることが多いです。
+
 
     ---
+    [:fontawesome-brands-github: __h-atsu__](https://github.com/h-atsu)
+
+    [:fontawesome-brands-x-twitter: __@H_A_ust__](https://x.com/H_A_ust)
+
+    
+
+    
 
 
 -   :material-account-outline: __Jiro Iwanaga__

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -13,13 +13,14 @@ theme:
   icon:
     repo: fontawesome/brands/github
   palette:
-    primary: grey
+    primary: white
 
 nav:
   - Home: index.md
   - Readings: readings.md
   - YouTube: youtube.md
   - Calendar: calendar.md
+  - Members: members.md
 
 plugins:
   - search:
@@ -28,4 +29,8 @@ plugins:
 markdown_extensions:
   - admonition
   - attr_list
+  - md_in_html
   - pymdownx.details
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg


### PR DESCRIPTION
こんな感じのページになります。

<img width="2362" height="2305" alt="image" src="https://github.com/user-attachments/assets/f30e07cf-f2f1-4729-b2e9-3b1640e17f40" />

みんなの分の自己紹介を埋めるために、以下をこの PR コメントに書いてください。
直接このブランチにコミットしちゃっても ok です。

- 掲載する画像のリンク
  - 正方形でお願いします
- 自己紹介文
  - 文字数の制限はありませんが、レイアウトの都合上ざっくり @sfujiwara の分量を目安にしてください
  - 短すぎるとレイアウト調整がちょっと面倒ですが、長い分には多分どうにかなります
- GitHub や X などのアカウント
  - 適当なアイコン + 文字列 (+ 必要であればリンク) を下の段に記載できるので、 @sfujiwara が書いている例以外のものでも ok です
  - たとえば、所属している会社とか、メールアドレスとか何でも
